### PR TITLE
fix: drop exclamation mark on sysusers u to fix installation error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+unbound (1.25.1-1deepin1) unstable; urgency=medium
+
+  * unbound.sysusers: Drop exclamation mark on u since our systemd
+    is not 257 yet.
+    https://github.com/systemd/systemd/pull/34876
+
+ -- lichenggang <lichenggang@uniontech.com>  Mon, 25 May 2026 16:00:00 +0800
+
 unbound (1.25.1-1) unstable; urgency=medium
 
   * new upstream security/bugfix release (Closes: #1137187):

--- a/debian/unbound.sysusers
+++ b/debian/unbound.sysusers
@@ -1,1 +1,1 @@
-u! unbound - "unbound" /var/lib/unbound /usr/sbin/nologin
+u unbound - "unbound" /var/lib/unbound /usr/sbin/nologin


### PR DESCRIPTION
Remove the exclamation mark modifier from u in unbound.sysusers because deepin's systemd version is below 257, which does not support the u! syntax introduced in systemd v257 (systemd/systemd#34876). This caused the post-installation script to fail with: "Unknown modifier 'u!'" during package configuration.

Log: Fixed unbound installation failure caused by unsupported sysusers modifier

Influence:
1. Install unbound package and verify no postinst errors
2. Check that unbound user is created correctly
3. Verify unbound service starts successfully

fix: 修复 sysusers 文件 u! 修饰符导致 unbound 安装失败

去掉 unbound.sysusers 中的感叹号修饰符，因为我们 deepin
系统环境中的 systemd 版本低于 257，不支持 v257 引入的 u! 语法
(systemd/systemd#34876)。
该问题导致安装时 postinst 脚本报错：
"Unknown modifier 'u!'"

Log: 修复 unbound 安装失败，原因是 sysusers 不支持的修饰符

Influence:
1. 安装 unbound 包，验证没有 postinst 错误
2. 检查 unbound 用户是否正确创建
3. 验证 unbound 服务正常启动

repo: unbound #master